### PR TITLE
Fix syntax error on Python 2

### DIFF
--- a/testpanel.py
+++ b/testpanel.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+from __future__ import print_function
 import sys
+
 import tkinter as tk
 from tkinter import filedialog
 from tkinter.tix import *


### PR DESCRIPTION
The test panel used to run on Python 2 but now it doesn't because of a single use of the `print()` function.  

```
$ pyflakes .
./hardware.py:3: 'greatfet.GreatFET' imported but unused
./hardware.py:5: 'greatfet.protocol.vendor_requests' imported but unused
./hardware.py:27: local variable 'state' is assigned to but never used
./testpanel.py:379:31: invalid syntax
		print(header, ' p', pin, sep='')
		                            ^
```

Adding the `__future__` import will fix it.